### PR TITLE
PR body override config

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,9 @@ Default: `"includePrBodyProd": true`
 
 #### writeChangelogToFile
 
-Flag to write information about the release to file. Writes the title & body of the PR creating the changelog, the version, the environement, and the timestamp to a JSON file. 
+Flag to write information about the release to file. Writes the title & body of the PR creating the changelog, the version, the environement, and the timestamp to a JSON file.
+
+This configuration option can be overridden by an individual PR. `<!-- changelogFile=true -->` or `<!-- changelogFile=false -->` in its own line in the body of a pull request will use that setting instead of this configuration option.
 
 Accepts a boolean.
 

--- a/src/changelog/changelog.ts
+++ b/src/changelog/changelog.ts
@@ -38,7 +38,6 @@ async function createChangelog (): Promise<void> {
         replaceVariable(variable, value)
       }
     } catch (e) {
-      console.error('oh no')
       console.error(e)
     }
   }))

--- a/src/changelog/utils/writePost.test.ts
+++ b/src/changelog/utils/writePost.test.ts
@@ -25,7 +25,22 @@ test('The pr title will not include markdown header', async () => {
   })
 })
 
+test('Overriding true from PR body writes changelog', async () => {
+  mockedWriteConfig = false
+  mockedPrBody = '<!-- changelogFile=true -->\nbody'
+  await writeChangelogPost()
+  expect(appendToChangelogFile).toBeCalled()
+})
+
+test('Overriding false from PR body does not changelog', async () => {
+  mockedWriteConfig = true
+  mockedPrBody = '<!-- changelogFile=false -->\nbody'
+  await writeChangelogPost()
+  expect(appendToChangelogFile).not.toBeCalled()
+})
+
 test('Having writeChangelogToFile config option disabled prevents writing posts', async () => {
+  mockedPrBody = 'No markdown body'
   mockedWriteConfig = false
   await writeChangelogPost()
   expect(appendToChangelogFile).not.toBeCalled()

--- a/src/changelog/utils/writePost.ts
+++ b/src/changelog/utils/writePost.ts
@@ -9,14 +9,18 @@ import { evaluatePrTitle } from '../variables/prTitle'
  * Writes a changelog post and appends it to the changelog file
  */
 export async function writeChangelogPost (): Promise<void> {
+  const prBody = await evaluatePrBody()
+  const override = getOverride(prBody)
+
   const writeChangelogToFile = getPackageJson().config.writeChangelogToFile
   const writeEmptyChangelogs = getPackageJson().config.writeEmptyChangelogs
-  if (!writeChangelogToFile) return
+  if (override === false) return
+  if (!writeChangelogToFile && override === undefined) return
 
   const prTitle = await evaluatePrTitle()
   const post = {
     title: prTitle.startsWith('\n# ') ? prTitle.substring('\n# '.length) : prTitle,
-    body: await evaluatePrBody(),
+    body: prBody,
     version: cleanVersionNumber(getPackageJson().version),
     env: evaluateEnvDeploy(),
     timestamp: (new Date()).toISOString()
@@ -27,4 +31,17 @@ export async function writeChangelogPost (): Promise<void> {
   if (!writeEmptyChangelogs && post.title === '' && post.body === '') return
 
   appendToChangelogFile(post)
+}
+
+/**
+ * Gets the override signal from the PR body, returns undefined
+ * if neither override exists
+ * @param prBody - the body of the pull request
+ * @returns true or false if an override signal exists, undefined if not
+ */
+function getOverride (prBody: string): boolean | undefined {
+  const lines = prBody.split('\n')
+  if (lines.includes('<!-- changelogFile=true -->')) return true
+  if (lines.includes('<!-- changelogFile=false -->')) return false
+  return undefined
 }


### PR DESCRIPTION
## Description <!-- Please be descriptive about what changes are being made and why -->
Allows users to override the config per PR for writing the changelog post to file with an override setting

## Tests <!-- Have these changes been tested? Unit tests? -->
Added 2 unit tests

## Related Issues <!-- Close the issues here if any exist -->
* Closes #171