### PR TITLE
Moved the reset changelog variable to inside the catch

### DIFF
--- a/src/changelog/changelog.ts
+++ b/src/changelog/changelog.ts
@@ -35,8 +35,6 @@ async function createChangelog (): Promise<void> {
     minimizeLevel++
   } while (body.length >= 125000)
 
-  console.warn('!!body', body)
-
   await createRelease(body)
 }
 
@@ -53,7 +51,6 @@ async function evaluateChangelog (minimizeLevel: number): Promise<string> {
       if (formatFileHasVariable(variable)) {
         if (variable === 'commitLog') {
           values[variable] = await evaluateCommitLog(minimizeLevel)
-          console.warn('!!commitLog', values[variable])
         } else {
           const evaluator = knownVariables.get(variable) as Evaluator
           values[variable] = await evaluator()
@@ -61,8 +58,8 @@ async function evaluateChangelog (minimizeLevel: number): Promise<string> {
       }
     } catch (e) {
       console.error(e)
+      values[variable] = ''
     }
-    values[variable] = ''
   }))
 
   return replaceVariables(values)


### PR DESCRIPTION
## Description <!-- Please be descriptive about what changes are being made and why -->
I was accidentally overwriting the variables in the changelog evaluator every time instead of just when there was an error

## Tests <!-- Have these changes been tested? Unit tests? -->
Unit tests

## Related Issues <!-- Close the issues here if any exist -->
Closes #207 