### PR TITLE
Handle empty PR bodies

### DIFF
--- a/src/API/mocks/octokit/endpoints/pulls.ts
+++ b/src/API/mocks/octokit/endpoints/pulls.ts
@@ -12,7 +12,7 @@ export interface MockedPR {
     ref: string
   }
   title: string
-  body: string
+  body: string | undefined
 }
 
 export const mockedPullData: MockedPR[] = [
@@ -61,6 +61,15 @@ export const mockedPullData: MockedPR[] = [
     base: { ref: 'some-branch4' },
     title: 'Mocked PR title 13',
     body: 'Mocked PR body 13'
+  }, {
+    id: 29,
+    submitted_at: (new Date()).toISOString(),
+    state: 'open',
+    reviewAuthors: [],
+    head: { ref: 'some-branch' },
+    base: { ref: 'main' },
+    title: 'Mocked PR title 1',
+    body: undefined
   }
 ]
 

--- a/src/changelog/variables/prBody.test.ts
+++ b/src/changelog/variables/prBody.test.ts
@@ -7,6 +7,12 @@ describe('Evaluate PR body', () => {
     expect(prBody).toBe('Mocked PR body 1')
   })
 
+  test('handles undefined body', async () => {
+    process.argv = ['node', 'octogration', 'changelog', '29']
+    const prBody = await evaluatePrBody()
+    expect(prBody).toBe('')
+  })
+
   test('unable to get invalid PR', async () => {
     process.argv = ['node', 'octogration', 'changelog', '1914841']
     const prBody = await evaluatePrBody()

--- a/src/changelog/variables/prBody.ts
+++ b/src/changelog/variables/prBody.ts
@@ -18,7 +18,9 @@ export async function evaluatePrBody (): Promise<string> {
 
   try {
     const number = process.argv[3]
-    return await retrieveGithubPrBody(number)
+    const body = await retrieveGithubPrBody(number)
+    if (body === undefined || body === null) return ''
+    return body
   } catch {
     return ''
   }
@@ -29,7 +31,7 @@ export async function evaluatePrBody (): Promise<string> {
  * @param number - the id of the PR to lookup
  * @returns the body of the PR in markdown
  */
-async function retrieveGithubPrBody (number: string): Promise<string> {
+async function retrieveGithubPrBody (number: string): Promise<string | undefined> {
   const request = `GET /repos/${getRepo()}/pulls/${number}`
   const pullInfo = await octokit.request(request)
   return pullInfo.data.body


### PR DESCRIPTION
## Description <!-- Please be descriptive about what changes are being made and why -->
Currently crashes when PR body is empty, now it just handles it as an empty string.

## Tests <!-- Have these changes been tested? Unit tests? -->
None

## Related Issues <!-- Close the issues here if any exist -->
* Closes #213